### PR TITLE
Update various rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added typescript to the import/resolver
+-   Added deprecated React types to the "ban-types" rule
+-   Added "complexity" rule with a maximum of 20
+-   Added "max-lines" rule with a maximum of 300 lines
+
+### Changed
+
+-   Updated "no-empty-function" rule to not allow any empty function
+-   Updated "quotes" rule by using the typescript version
+-   Updated "react/no-unstable-nested-components" rule to allow component creation inside component props
+
 ## [1.1.0] - 2022-10-17
 
 ### Added

--- a/rules/eslint.js
+++ b/rules/eslint.js
@@ -4,18 +4,22 @@ module.exports = {
   ].map(require.resolve),
 
   // View link below for eslint rules documentation
-  // https://eslint.org/docs/latest/rules/
+  // https://eslint.org/docs/rules/
   rules: {
     // The airbnb config enforce that class methods use "this", but requires changing how you call the method
-    // https://eslint.org/docs/latest/rules/class-methods-use-this
+    // https://eslint.org/docs/rules/class-methods-use-this
     "class-methods-use-this": "off",
 
+    // The airbnb config disables the complexity, but we want to limit it
+    // https://eslint.org/docs/rules/complexity
+    complexity: ["error", 20],
+
     // The airbnb config enforces consistent return, but we got problems with some external libraries, TypeScript enforces this anyway
-    // https://eslint.org/docs/latest/rules/consistent-return
+    // https://eslint.org/docs/rules/consistent-return
     "consistent-return": "off",
 
     // The airbnb config forces unix style, but somebody also works on windows
-    // https://eslint.org/docs/latest/rules/linebreak-style
+    // https://eslint.org/docs/rules/linebreak-style
     "linebreak-style": "off",
 
     // The airbnb config limits to 100 ignoring some lines, instad we allow 160 but don't ignore lines
@@ -29,12 +33,20 @@ module.exports = {
       ignoreRegExpLiterals: false,
     }],
 
+    // The airbnb disables the max lines, but we want to limit it
+    // https://eslint.org/docs/rules/max-lines
+    "max-lines": ["error", {
+      max: 300,
+      skipBlankLines: true,
+      skipComments: true
+    }],
+
     // The airbnb config disallow await inside of loops, but it cannot always be avoided
     // https://eslint.org/docs/rules/no-await-in-loop
     "no-await-in-loop": "off",
 
     // The airbnb config disallow use of the continue statement, but it's ok to have it
-    // https://eslint.org/docs/latest/rules/no-continue
+    // https://eslint.org/docs/rules/no-continue
     "no-continue": "off",
 
     // The airbnb config disallow use of unary operators (++ and --), but it's ok to have them
@@ -42,7 +54,7 @@ module.exports = {
     "no-plusplus": "off",
 
     // The airbnb config also restrict ForOfStatement, but we want to use it
-    // https://eslint.org/docs/latest/rules/no-restricted-syntax
+    // https://eslint.org/docs/rules/no-restricted-syntax
     "no-restricted-syntax": [
       "error",
       {
@@ -59,9 +71,5 @@ module.exports = {
         message: "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
       },
     ],
-
-    // The airbnb config forces single quote, but we prefer double quote
-    // https://eslint.org/docs/latest/rules/quotes
-    quotes: ["error", "double", { avoidEscape: true }],
   },
 };

--- a/rules/import.js
+++ b/rules/import.js
@@ -10,8 +10,11 @@ module.exports = {
   settings: {
     "import/resolver": {
       node: {
-        extensions: [".js", ".jsx", ".ts", ".tsx"]
-      }
+        extensions: [".js", ".jsx", ".ts", ".tsx"],
+      },
+      typescript: {
+        alwaysTryTypes: true,
+      },
     },
   },
 

--- a/rules/react.js
+++ b/rules/react.js
@@ -21,6 +21,10 @@ module.exports = {
     // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-one-expression-per-line.md
     "react/jsx-one-expression-per-line": "off",
 
+    // The airbnb config didn't allow component creation inside component props, but we want to allow it
+    // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md
+    "react/no-unstable-nested-components": ["error", { allowAsProps: true }],
+
     // The airbnb config forces a defaultProps definition for every prop, but we don't want it
     // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-default-props.md
     "react/require-default-props": "off",

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -16,6 +16,18 @@ module.exports = {
   // View link below for typescript rules documentation
   // https://typescript-eslint.io/rules/
   rules: {
+    // Disallow certain types
+    // https://typescript-eslint.io/rules/ban-types/
+    "@typescript-eslint/ban-types": ["error",{
+      types: {
+        "React.StatelessComponent": { message: "Deprecated: Do not use.", fixWith: "React.ReactElement" },
+        StatelessComponent: { message: "Deprecated: Do not use.", fixWith: "ReactElement" },
+        "React.FC": { message: "Please use ReactElement + PropsWithChildren", fixWith: "ReactElement" },
+        FC: { message: "Please use ReactElement + PropsWithChildren", fixWith: "ReactElement" },
+      },
+      extendDefaults: true,
+    }],
+
     // Enforce one true brace style (same as eslint-config-airbnb-base)
     // https://typescript-eslint.io/rules/brace-style
     "@typescript-eslint/brace-style": ["error", "1tbs", { allowSingleLine: true }],
@@ -108,14 +120,10 @@ module.exports = {
       format: ["PascalCase"],
     }],
 
-    // Disallow empty functions, except for standalone funcs/arrows (same as eslint-config-airbnb-base)
+    // Disallow empty functions
     // https://typescript-eslint.io/rules/no-empty-function
     "@typescript-eslint/no-empty-function": ["error", {
-      allow: [
-        "arrowFunctions",
-        "functions",
-        "methods",
-      ]
+      allow: [],
     }],
 
     // Disallow unnecessary parentheses (same as eslint-config-airbnb-base)
@@ -171,6 +179,11 @@ module.exports = {
     // Require function parameters to be typed as readonly to prevent accidental mutation of inputs
     // https://typescript-eslint.io/rules/prefer-readonly-parameter-types
     "@typescript-eslint/prefer-readonly-parameter-types": "off",
+
+    // Enforce the consistent use of double quotes, but allow single quotes so long as the
+    // string contains a quote that would have to be escaped otherwise
+    // https://typescript-eslint.io/rules/quotes
+    "@typescript-eslint/quotes": ["error", "double", { avoidEscape: true }],
 
     // Require `await` in `async function` (note: this is a horrible rule that should never be used) (same as eslint-config-airbnb-base)
     // https://typescript-eslint.io/rules/require-await


### PR DESCRIPTION
-   Added typescript to the import/resolver
-   Added deprecated React types to the "ban-types" rule
-   Added "complexity" rule with a maximum of 20
-   Added "max-lines" rule with a maximum of 300 lines
-   Updated "no-empty-function" rule to not allow any empty function
-   Updated "quotes" rule by using the typescript version
-   Updated "react/no-unstable-nested-components" rule to allow component creation inside component props
